### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources


### PR DESCRIPTION
Potential fix for [https://github.com/Uni0305/gadget/security/code-scanning/3](https://github.com/Uni0305/gadget/security/code-scanning/3)

To fix this issue, add a `permissions` block with the minimum required privileges. The safest option is to set restricted permissions at the job level for the `build` job, since only that job exists, and it runs all necessary steps. Based on the actions used:  
- `actions/checkout` (`contents: read` for code access)  
- `actions/upload-artifact` and `softprops/action-gh-release` (`contents: write` to publish releases/artifacts)  
So, for the release step, `contents: write` is needed only when `refs/tags/*` (release) is triggered, but safest is to specify `contents: write` for the whole job (to avoid permissions issues in release).  
Add the following block under `build:`:
```yaml
permissions:
  contents: write
```
Optionally, further restrict (`pull-requests: write` or similar) only if features require; otherwise, only `contents: write` is enough.  
This change should be made in `.github/workflows/build.yml`, right below the `build:` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
